### PR TITLE
docs(SWA-1206): add gasless submitTx endpoint and update getAction API reference

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -53,6 +53,10 @@
             "pages": ["GET /getAction", "GET /getStatus", "POST /registerTxs"]
           },
           {
+            "group": "Gasless",
+            "pages": ["POST /submitTx"]
+          },
+          {
             "group": "Data",
             "pages": ["GET /getTransactions"]
           },

--- a/guides/preview/gasless.mdx
+++ b/guides/preview/gasless.mdx
@@ -1,229 +1,284 @@
-# Gasless Transactions
+---
+title: "Gasless Transactions"
+description: "Execute sponsored meta-transactions without requiring users to hold native tokens for gas."
+---
 
-> Execute sponsored meta-transactions without requiring users to hold native tokens for gas.
+import { Callout } from "/snippets/Callout.jsx";
+
+**API Reference:** [GET /getAction](/swap-api-reference/overview) · [POST /submitTx](/swap-api-reference/overview)
 
 This guide extends the standard [Swaps.xyz swap flow](https://docs.swaps.xyz/guides/swap) with optional gasless execution.
 
 ## Overview
 
-Gasless transactions allow users to execute swaps and bridges without paying gas fees directly. The API handles meta-transaction encoding and submission to a relay service.
+Gasless transactions allow users to execute swaps without paying gas fees directly. When `gasless=true` is passed to `getAction`, the API returns a set of signing steps (`executions`) instead of a raw transaction. The user signs each step and submits them to `POST /submitTx`, which handles relay and broadcast.
 
-**Supported Chains:** Tron (EVM chains coming soon)
+**Supported Chains:** Tron same-chain swaps only (cross-chain and EVM chains coming soon)
+
+<Callout type="info">
+  Gasless execution requires your API key to have gasless enabled. Contact the Swaps team if you need access.
+</Callout>
 
 ---
 
 ## Requesting Gasless Execution
 
-Add the optional `gasless` parameter to your `ActionRequest`:
+Add the optional `gasless` query parameter to your `getAction` request:
 
 ```typescript
-const actionRequest = {
+const params = new URLSearchParams({
   actionType: "swap-action",
   sender: "TRiskt1RqdWMfvWEU8CMxSBh3MPSPP9UoL",
   srcToken: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t", // USDT on Tron
   dstToken: "0x0000000000000000000000000000000000000000", // TRX on Tron
-  srcChainId: 728126428, // Tron
-  dstChainId: 728126428,
-  slippage: 100,
+  srcChainId: "728126428",
+  dstChainId: "728126428",
+  slippage: "100",
   swapDirection: "exact-amount-in",
-  amount: 1000000n,
+  amount: "1000000",
   recipient: "TRiskt1RqdWMfvWEU8CMxSBh3MPSPP9UoL",
-  gasless: true, // ← Request gasless execution
-};
+  gasless: "true", // ← Request gasless execution
+});
+
+const actionResponse = await fetch(
+  `https://api-v2.swaps.xyz/api/getAction?${params}`,
+  { headers: { "x-api-key": YOUR_API_KEY } }
+).then((r) => r.json());
 ```
 
-> **Note:** Omit `gasless` or set to `false` for standard transactions.
+> **Note:** Omit `gasless` or set it to `false` for standard transactions.
 
 ---
 
 ## Understanding the Response
 
-The API response includes an `execute` field that describes how to execute the transaction:
+When `gasless=true` is requested and a relay provider is available for the source chain, the response includes:
+
+| Field | Description |
+|-------|-------------|
+| `executionsType` | `"GASLESS"` — indicates relay execution |
+| `executions` | Ordered array of signing steps |
+| `relayerFee` | Fee charged by the relay, denominated in USDT. If non-zero, the user must hold USDT in addition to the source token |
+| `txId` | Unique action ID returned by `getAction` — required when calling `POST /submitTx` |
 
 ```typescript
-interface ActionResponse {
-  tx: Transaction;
-  execute: {
-    type: "STANDARD" | "GASLESS";
-    approval: ExecutionStep | null;
-    tx: ExecutionStep;
-  };
-  // ... other fields
-}
-```
-
-### Standard Execution
-
-```typescript
+// Example gasless getAction response (simplified)
 {
-  type: "STANDARD",
-  approval: null,
-  tx: {
-    type: "BROADCAST",
-    input: { to, data, value, chainId } // Standard transaction
-  }
-}
-```
-
-**Action:** Broadcast `tx` directly on-chain (see [Swaps.xyz broadcast guide](https://docs.swaps.xyz/guides/swap)).
-
-### Gasless Execution
-
-```typescript
-{
-  type: "GASLESS",
-  approval: null,
-  tx: {
-    type: "SIGN_TYPED_DATA",
-    input: {
-      domain: { name, version, chainId, verifyingContract },
-      types: { MetaTransaction: [...] },
-      message: { nonce, from, functionSignature }
+  txId: "0xabc123...",
+  executionsType: "GASLESS",
+  relayerFee: { amount: "5000000", token: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t", ... },
+  executions: [
+    // Step 1 (if needed): approve relay fee transfer
+    {
+      txType: "tronTransactionSign",
+      data: "{...unsigned Tron transaction JSON...}"
+    },
+    // Step 2: sign the swap meta-transaction
+    {
+      txType: "evmSignTypedData",
+      to: "TTRr81XJt6zESpJw2zHgJNAsxcsyT5MVYv",
+      data: {
+        domain: { name: "SunSwapProxy", version: "1", chainId: 728126428, verifyingContract: "..." },
+        types: { MetaTransaction: [{ name: "nonce", type: "uint256" }, ...] },
+        message: { nonce: 0, from: "0x...", functionSignature: "0x..." }
+      }
     }
-  }
+  ],
+  // ... standard fields: amountIn, amountOut, tx, etc.
 }
 ```
 
-**Action:** Sign the EIP-712 data and submit to `/api/submit`.
+If `executionsType` is `"DEFAULT"` (relay unavailable or `gasless` not set), broadcast `tx` directly as a standard transaction — see the [swap guide](https://docs.swaps.xyz/guides/swap).
 
 ---
 
 ## Executing Gasless Transactions
 
-### Step 1: Handle Approval (if required)
+<Steps>
+<Step title="Check executionsType">
 
-If `execute.approval` exists, sign it first before the main transaction:
+Always check the response before proceeding:
 
 ```typescript
-const { execute } = actionResponse;
-
-if (execute.approval) {
-  if (execute.approval.type === "SIGN_TYPED_DATA") {
-    const { domain, types, message } = execute.approval.input;
-    execute.approval.output = await wallet.signTypedData(
-      domain,
-      types,
-      message
-    );
-  } else if (execute.approval.type === "SIGN_TRANSACTION") {
-    const signedTx = await wallet.signTransaction(execute.approval.input);
-    execute.approval.output = signedTx;
-  }
+if (actionResponse.executionsType !== "GASLESS") {
+  // Fall back to standard broadcast
+  return broadcastStandardTx(actionResponse.tx);
 }
 ```
 
-### Step 2: Sign Main Transaction
+</Step>
+<Step title="Sign each execution in order">
+
+Iterate `executions` and sign each step with the appropriate wallet method:
 
 ```typescript
-if (execute.tx.type === "SIGN_TYPED_DATA") {
-  const { domain, types, message } = execute.tx.input;
-  execute.tx.output = await wallet.signTypedData(domain, types, message);
-} else if (execute.tx.type === "SIGN_TRANSACTION") {
-  const signedTx = await wallet.signTransaction(execute.tx.input);
-  execute.tx.output = signedTx;
-}
+const signedExecutions = await Promise.all(
+  actionResponse.executions.map(async (execution) => {
+    if (execution.txType === "tronTransactionSign") {
+      // Sign an unsigned Tron transaction
+      const unsignedTx = JSON.parse(execution.data);
+      const signedTx = await tronWeb.trx.sign(unsignedTx);
+      return {
+        ...execution,
+        signature: signedTx.signature[0],
+        data: JSON.stringify(signedTx),
+      };
+    }
+
+    if (execution.txType === "evmSignTypedData") {
+      // Sign EIP-712 typed data (swap meta-transaction)
+      const { domain, types, message } = execution.data;
+      const signature = await tronWeb.trx.signTypedData(domain, types, message);
+      return { ...execution, signature };
+    }
+
+    return execution;
+  })
+);
 ```
 
-### Step 3: Submit to Backend
+> **Order matters.** Fee approval steps (if present) must be signed and submitted before the swap step. The array is already in the correct order.
+
+</Step>
+<Step title="Submit to POST /submitTx">
+
+Send the signed executions along with the `txId` from the `getAction` response:
 
 ```typescript
-const response = await fetch("https://api-v2.swaps.xyz/api/submit", {
+const submitResponse = await fetch("https://api-v2.swaps.xyz/api/submitTx", {
   method: "POST",
   headers: {
     "Content-Type": "application/json",
     "x-api-key": YOUR_API_KEY,
   },
   body: JSON.stringify({
-    chainId: actionRequest.srcChainId,
-    approval: execute.approval, // null or SignedExecutionStep
-    tx: execute.tx, // SignedExecutionStep
+    txId: actionResponse.txId,
+    chainId: 728126428, // srcChainId
+    executions: signedExecutions,
   }),
 });
 
-const result = await response.json();
-// { success: true, id: "relay-task-id" }
+const result = await submitResponse.json();
+// { success: true, txId: "internal-tx-id" }
+// Pass txId to GET /getStatus to poll for the on-chain transaction hash
 ```
 
----
-
-## Notes
-
-- **Approval Handling:** The `approval` step (if present) must be signed before the main transaction. It can be either `SIGN_TRANSACTION` (for airdrop approvals) or `SIGN_TYPED_DATA` (for permit approvals)
-- **Standard Fallback:** Always check `execute.type` - if `"STANDARD"`, broadcast the `tx` directly (see [Swaps.xyz broadcast guide](https://docs.swaps.xyz/guides/swap))
-- **Error Handling:** The `/api/submit` endpoint validates signatures and simulates transactions before broadcasting
+</Step>
+</Steps>
 
 ---
 
 ## Complete Example
 
 ```typescript
+const YOUR_API_KEY = "...";
+const TRON_CHAIN_ID = 728126428;
+
 // 1. Request gasless action
-const actionRequest = { ...params, gasless: true };
-const actionResponse = await getAction(actionRequest);
+const params = new URLSearchParams({
+  actionType: "swap-action",
+  sender: "TRiskt1RqdWMfvWEU8CMxSBh3MPSPP9UoL",
+  srcToken: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+  dstToken: "0x0000000000000000000000000000000000000000",
+  srcChainId: String(TRON_CHAIN_ID),
+  dstChainId: String(TRON_CHAIN_ID),
+  slippage: "100",
+  swapDirection: "exact-amount-in",
+  amount: "1000000",
+  recipient: "TRiskt1RqdWMfvWEU8CMxSBh3MPSPP9UoL",
+  gasless: "true",
+});
 
-// 2. Check execution type
-if (actionResponse.execute.type === "GASLESS") {
-  const { execute } = actionResponse;
+const actionResponse = await fetch(
+  `https://api-v2.swaps.xyz/api/getAction?${params}`,
+  { headers: { "x-api-key": YOUR_API_KEY } }
+).then((r) => r.json());
 
-  // 3. Sign approval if required
-  if (execute.approval) {
-    const { domain, types, message } = execute.approval.input;
-    execute.approval.output = await wallet.signTypedData(
-      domain,
-      types,
-      message
-    );
-  }
-
-  // 4. Sign main transaction
-  const { domain, types, message } = execute.tx.input;
-  execute.tx.output = await wallet.signTypedData(domain, types, message);
-
-  // 5. Submit for broadcast
-  const submitResponse = await fetch("/api/submit", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "x-api-key": YOUR_API_KEY,
-    },
-    body: JSON.stringify({
-      chainId: actionRequest.srcChainId,
-      approval: execute.approval,
-      tx: execute.tx,
-    }),
-  });
-
-  const { success, id } = await submitResponse.json();
-  console.log(`Transaction submitted: ${id}`);
+// 2. Fall back to standard flow if relay unavailable
+if (actionResponse.executionsType !== "GASLESS") {
+  return broadcastStandardTx(actionResponse.tx);
 }
+
+// 3. Sign each execution in order
+const signedExecutions = await Promise.all(
+  actionResponse.executions.map(async (execution) => {
+    if (execution.txType === "tronTransactionSign") {
+      const unsignedTx = JSON.parse(execution.data);
+      const signedTx = await tronWeb.trx.sign(unsignedTx);
+      return { ...execution, signature: signedTx.signature[0], data: JSON.stringify(signedTx) };
+    }
+    if (execution.txType === "evmSignTypedData") {
+      const { domain, types, message } = execution.data;
+      const signature = await tronWeb.trx.signTypedData(domain, types, message);
+      return { ...execution, signature };
+    }
+    return execution;
+  })
+);
+
+// 4. Submit for relay broadcast
+const { success, txId } = await fetch("https://api-v2.swaps.xyz/api/submitTx", {
+  method: "POST",
+  headers: { "Content-Type": "application/json", "x-api-key": YOUR_API_KEY },
+  body: JSON.stringify({
+    txId: actionResponse.txId,
+    chainId: TRON_CHAIN_ID,
+    executions: signedExecutions,
+  }),
+}).then((r) => r.json());
+
+// Poll GET /getStatus with txId to get the on-chain transaction hash
+console.log(`Relay accepted. Poll getStatus with txId: ${txId}`);
 ```
+
+---
+
+## Notes
+
+- **Standard fallback:** Always check `executionsType` — if `"DEFAULT"`, broadcast `tx` directly (see [swap guide](https://docs.swaps.xyz/guides/swap)).
+- **Error handling:** `POST /submitTx` validates signatures and simulates transactions before broadcasting. A `400` response indicates a bad signature or expired `txId`.
+- **Relayer fee:** The `relayerFee` field shows the fee deducted from `amountIn` to pay the relay. Display it to users alongside the swap quote.
 
 ---
 
 ## Type Definitions
 
 ```typescript
-type ExecutionStepType = "BROADCAST" | "SIGN_TRANSACTION" | "SIGN_TYPED_DATA";
+type ExecutionTxType = "tronTransactionSign" | "evmSignTypedData";
 
-interface ExecutionStep {
-  type: ExecutionStepType;
-  input: Transaction | EIP712TypedData;
+interface BaseExecution {
+  txType: ExecutionTxType;
+  signature: string; // populated by the client after signing
 }
 
-interface SignedExecutionStep extends ExecutionStep {
-  output: string; // Signature or signed transaction
+interface TronTransactionSignExecution extends BaseExecution {
+  txType: "tronTransactionSign";
+  data: string; // JSON string of unsigned Tron transaction (TronWeb raw_data shape)
 }
 
-interface PostSubmitRequest {
+interface EvmSignTypedDataExecution extends BaseExecution {
+  txType: "evmSignTypedData";
+  to: string; // verifying contract address
+  data: Eip712Data;
+}
+
+type Execution = TronTransactionSignExecution | EvmSignTypedDataExecution;
+
+interface Eip712Data {
+  domain: { name: string; version: string; chainId: number; verifyingContract: string };
+  types: Record<string, { name: string; type: string }[]>;
+  message: Record<string, unknown>;
+}
+
+interface SubmitTxRequest {
+  txId: string;
   chainId: number;
-  approval: SignedExecutionStep | null;
-  tx: SignedExecutionStep;
+  executions: Execution[];
 }
 
-interface PostSubmitResponse {
+interface SubmitTxResponse {
   success: boolean;
-  id?: string; // Relay task ID
+  txId?: string; // internal ID — pass to GET /getStatus to get the on-chain transaction hash
+  error?: string;
 }
 ```
-
----

--- a/swap-api-reference/openapi.json
+++ b/swap-api-reference/openapi.json
@@ -289,6 +289,16 @@
               "type": "string",
               "enum": ["true", "false"]
             }
+          },
+          {
+            "name": "gasless",
+            "in": "query",
+            "required": false,
+            "description": "Request gasless execution. When `true`, the response includes an `executions` array of signed steps to relay through the gasless provider instead of broadcasting a transaction directly.\n\n**Optional:** Only supported on chains with a configured gasless provider (currently Tron). Requires the API key to have gasless enabled.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
           }
         ],
         "responses": {
@@ -1601,6 +1611,66 @@
           }
         }
       }
+    },
+    "/submitTx": {
+      "post": {
+        "summary": "Submit Gasless Transaction",
+        "servers": [
+          {
+            "url": "https://api-v2.swaps.xyz/api",
+            "description": "Core Swap API server"
+          }
+        ],
+        "description": "Submits signed executions obtained from a gasless `GET /getAction` response for relay broadcast. The backend validates each signature, simulates the transactions, then broadcasts them via the configured relay provider.\n\nCall this endpoint only when `executionsType` is `GASLESS` in the `getAction` response. Sign all items in the `executions` array in order before submitting.",
+        "operationId": "submitTx",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubmitTxRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Transaction accepted for relay broadcast",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubmitTxResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid signature, unknown txId, or malformed executions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized — missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -1723,6 +1793,22 @@
               "$ref": "#/components/schemas/BaseActionResponse"
             },
             "description": "All available routes for the action."
+          },
+          "executionsType": {
+            "type": "string",
+            "enum": ["DEFAULT", "GASLESS"],
+            "description": "Indicates the execution mode. `GASLESS` when `gasless=true` was requested and a relay provider is available; `DEFAULT` otherwise."
+          },
+          "executions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Execution"
+            },
+            "description": "Ordered list of signing steps the client must complete before calling `POST /submitTx`. Only present when `executionsType` is `GASLESS`."
+          },
+          "relayerFee": {
+            "$ref": "#/components/schemas/Payment",
+            "description": "Fee charged by the relay provider, denominated in USDT. If non-zero, the user must hold USDT in addition to the source token. Only present when `executionsType` is `GASLESS`."
           }
         }
       },
@@ -1831,12 +1917,136 @@
           "requiresRegisterTransaction": {
             "type": "boolean",
             "description": "Flag indicating whether the transaction requires registration via the registerTxs endpoint. Mandatory for non-EVM transactions."
+          },
+          "executionsType": {
+            "type": "string",
+            "enum": ["DEFAULT", "GASLESS"],
+            "description": "Indicates the execution mode. `GASLESS` when `gasless=true` was requested and a relay provider is available; `DEFAULT` otherwise."
+          },
+          "executions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Execution"
+            },
+            "description": "Ordered list of signing steps the client must complete before calling `POST /submitTx`. Only present when `executionsType` is `GASLESS`."
+          },
+          "relayerFee": {
+            "$ref": "#/components/schemas/Payment",
+            "description": "Fee charged by the relay provider, denominated in USDT. If non-zero, the user must hold USDT in addition to the source token. Only present when `executionsType` is `GASLESS`."
           }
         }
       },
       "ChainId": {
         "type": "integer",
         "description": "Chain ID. Find in the list of supported networks."
+      },
+      "Eip712Domain": {
+        "type": "object",
+        "required": ["name", "version", "chainId", "verifyingContract"],
+        "properties": {
+          "name": { "type": "string", "description": "EIP-712 domain name" },
+          "version": { "type": "string", "description": "EIP-712 domain version" },
+          "chainId": { "type": "integer", "description": "Chain ID the typed data is bound to" },
+          "verifyingContract": { "type": "string", "description": "Address of the contract verifying the signature" }
+        }
+      },
+      "Eip712Data": {
+        "type": "object",
+        "required": ["domain", "types", "message"],
+        "properties": {
+          "domain": { "$ref": "#/components/schemas/Eip712Domain" },
+          "types": {
+            "type": "object",
+            "description": "EIP-712 type definitions (field name → array of {name, type} pairs)",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": { "type": "string" },
+                  "type": { "type": "string" }
+                }
+              }
+            }
+          },
+          "message": {
+            "type": "object",
+            "description": "The typed data message payload",
+            "additionalProperties": true
+          }
+        }
+      },
+      "TronTransactionSignExecution": {
+        "type": "object",
+        "required": ["txType", "data", "signature"],
+        "properties": {
+          "txType": { "type": "string", "enum": ["tronTransactionSign"] },
+          "data": { "type": "string", "description": "JSON string of an unsigned Tron transaction (TronWeb `raw_data` shape)" },
+          "signature": { "type": "string", "description": "Hex-encoded signature from TronLink or compatible Tron wallet" }
+        }
+      },
+      "EvmSignTypedDataExecution": {
+        "type": "object",
+        "required": ["txType", "to", "data", "signature"],
+        "properties": {
+          "txType": { "type": "string", "enum": ["evmSignTypedData"] },
+          "to": { "type": "string", "description": "Address of the verifying contract" },
+          "data": { "$ref": "#/components/schemas/Eip712Data", "description": "EIP-712 typed data to sign" },
+          "signature": { "type": "string", "description": "Hex-encoded EIP-712 signature" }
+        }
+      },
+      "Execution": {
+        "description": "A single signing step returned in the `executions` array of a gasless `getAction` response. Only available for Tron same-chain swaps. The client must sign each item in order and include the signatures when calling `POST /submitTx`.",
+        "oneOf": [
+          { "$ref": "#/components/schemas/TronTransactionSignExecution" },
+          { "$ref": "#/components/schemas/EvmSignTypedDataExecution" }
+        ],
+        "discriminator": {
+          "propertyName": "txType",
+          "mapping": {
+            "tronTransactionSign": "#/components/schemas/TronTransactionSignExecution",
+            "evmSignTypedData": "#/components/schemas/EvmSignTypedDataExecution"
+          }
+        }
+      },
+      "SubmitTxRequest": {
+        "type": "object",
+        "required": ["txId", "chainId", "executions"],
+        "properties": {
+          "txId": {
+            "type": "string",
+            "description": "The `txId` from the `GET /getAction` quote response. Used to correlate the signed executions with the original action on the relay."
+          },
+          "chainId": {
+            "$ref": "#/components/schemas/ChainId",
+            "description": "Source chain ID of the swap."
+          },
+          "executions": {
+            "type": "array",
+            "description": "All execution steps from the `getAction` response, each with a `signature` field populated by the user's wallet. Must be in the same order as returned by `getAction`.",
+            "items": {
+              "$ref": "#/components/schemas/Execution"
+            }
+          }
+        }
+      },
+      "SubmitTxResponse": {
+        "type": "object",
+        "required": ["success"],
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "Whether the relay broadcast was accepted."
+          },
+          "txId": {
+            "type": "string",
+            "description": "Internal transaction ID. Pass this to `GET /getStatus` to poll for completion — the status endpoint will return the on-chain transaction hash once the relay broadcast confirms."
+          },
+          "error": {
+            "type": "string",
+            "description": "Error message when `success` is `false`."
+          }
+        }
       },
       "VmId": {
         "type": "string",


### PR DESCRIPTION
## 💡 Motivation

The gasless Tron swap feature (SWA-1204/SWA-1206) introduced new API surface that was not reflected in the public docs: the `gasless` query parameter on `getAction` and the `POST /submitTx` endpoint for relay submission.

## 🔧 Modification

- `swap-api-reference/openapi.json`
  - Added `gasless` optional boolean parameter to `GET /getAction`
  - Added gasless response fields to `ActionResponse` and `BaseActionResponse`: `executionsType`, `executions`, `relayerFee`
  - Added `POST /submitTx` endpoint with full request/response definition
  - Added new schemas: `Execution` (discriminated oneOf), `TronTransactionSignExecution`, `EvmSignTypedDataExecution`, `Eip712Domain`, `Eip712Data`, `SubmitTxRequest`, `SubmitTxResponse`
- `docs.json` — added "Gasless" group under Swap API Reference tab with `POST /submitTx`
- `guides/preview/gasless.mdx` — rewrote to match the real API: correct endpoint (`/submitTx`), correct request shape (`{ txId, chainId, executions }`), Tron-only signing examples, clarified `relayerFee` is denominated in USDT, clarified `txId` in response is an internal ID for `GET /getStatus`

## 📋 Expected Result

The Swap API Reference tab shows `POST /submitTx` with interactive request/response docs. `GET /getAction` shows the `gasless` parameter. The gasless guide reflects the real submission flow.