### PR TITLE
fix(SWA-1639): remove bad ghost.swaps.xyz URL from openapi spec

### DIFF
--- a/swap-api-reference/openapi.json
+++ b/swap-api-reference/openapi.json
@@ -13,10 +13,6 @@
     {
       "url": "https://api-v2.swaps.xyz/api",
       "description": "Production server"
-    },
-    {
-      "url": "https://ghost.swaps.xyz/api/v2",
-      "description": "Production server"
     }
   ],
   "paths": {
@@ -991,6 +987,12 @@
     "/getPaths": {
       "get": {
         "summary": "Get Paths",
+        "servers": [
+          {
+            "url": "https://api-v2.swaps.xyz/api",
+            "description": "Core Swap API server"
+          }
+        ],
         "description": "Retrieves all available token paths across supported chains with configurable filtering options. It’s recommended to call this endpoint after selecting the source and destination tokens to validate route eligibility.",
         "operationId": "getPaths",
         "parameters": [
@@ -1092,6 +1094,12 @@
     "/getChainList": {
       "get": {
         "summary": "Get Chain List",
+        "servers": [
+          {
+            "url": "https://api-v2.swaps.xyz/api",
+            "description": "Core Swap API server"
+          }
+        ],
         "description": "Retrieve a list of supported chains, their names, and virtual machine identifiers. Raw data for the [supported chains list](/resources/chain-list).",
         "operationId": "getChainList",
         "responses": {


### PR DESCRIPTION
## 💡 Motivation

The top-level `servers` array in `swap-api-reference/openapi.json` contained a spurious internal URL (`https://ghost.swaps.xyz/api/v2`) labelled as "Production server". This caused:
- Clients (Postman, Mintlify playground, etc.) to see an invalid server option.
- `GET /getPaths` and `GET /getChainList` — the two operations with no per-operation server override — to fall back to both top-level servers, including the bad ghost URL.

Fixes [SWA-1639](https://linear.app/moonpay/issue/SWA-1639).

## 🔧 Modification

- Removed `https://ghost.swaps.xyz/api/v2` from the top-level `servers` array; only `https://api-v2.swaps.xyz/api` remains.
- Added explicit `servers` overrides to `GET /getPaths` and `GET /getChainList` so all 12 operations consistently point to `https://api-v2.swaps.xyz/api`.

## 📋 Expected Result

The openapi spec now returns only the correct production URL (`https://api-v2.swaps.xyz/api`) for all endpoints, with no ghost/staging URL exposed.